### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/pt/book.toml
+++ b/pt/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["AUTOR"]
 language = "pt"
-multilingual = true
 src = "src"
 title = "TITULO DO SEU LIVRO AQUI"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10